### PR TITLE
Add til section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,8 +19,7 @@ title: Chandler Thompson # the main title
 tagline: Thoughts and opinions are my own # it will display as the subtitle
 
 description: >- # used by seo meta and the atom feed, e.g., A minimal, responsive and feature-rich Jekyll theme for technical writing.
-  A personal blog where I share thoughts on software engineering, game development, 
-  productivity, and whatever else sparks my curiosity.
+  A personal blog where I share thoughts on software engineering, game design, and whatever else sparks my curiosity.
 
 # Fill in the protocol & hostname for your site.
 # E.g. 'https://username.github.io', note that it does not end with a '/'.
@@ -171,6 +170,16 @@ collections:
   tabs:
     output: true
     sort_by: order
+  til:
+    output: true
+    layout: post
+    permalink: /til/:title/
+
+jekyll_compose:
+  default_front_matter:
+    til:
+      layout: "til"
+      refactor: true
 
 defaults:
   - scope:
@@ -193,6 +202,12 @@ defaults:
     values:
       layout: page
       permalink: /:title/
+  - scope:
+      path: "" # An empty string here means all files in the project
+      type: til
+    values:
+      layout: til
+      comments: true
 
 sass:
   style: compressed

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,127 @@
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f7f7f7">
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1b1b1e">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta
+      name="viewport"
+      content="width=device-width, user-scalable=no initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+    >
+  
+    {%- capture seo_tags -%}
+      {% seo title=false %}
+    {%- endcapture -%}
+  
+    <!-- Setup Open Graph image -->
+  
+    {% if page.image %}
+      {% assign src = page.image.path | default: page.image %}
+  
+      {% unless src contains '://' %}
+        {%- capture img_url -%}
+          {% include media-url.html src=src subpath=page.media_subpath absolute=true %}
+        {%- endcapture -%}
+  
+        {%- capture old_url -%}{{ src | absolute_url }}{%- endcapture -%}
+        {%- capture new_url -%}{{ img_url }}{%- endcapture -%}
+  
+        {% assign seo_tags = seo_tags | replace: old_url, new_url %}
+      {% endunless %}
+  
+    {% elsif site.social_preview_image %}
+      {%- capture img_url -%}
+        {% include media-url.html src=site.social_preview_image absolute=true %}
+      {%- endcapture -%}
+  
+      {%- capture og_image -%}
+        <meta property="og:image" content="{{ img_url }}" />
+      {%- endcapture -%}
+  
+      {%- capture twitter_image -%}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta property="twitter:image" content="{{ img_url }}" />
+      {%- endcapture -%}
+  
+      {% assign old_meta_clip = '<meta name="twitter:card" content="summary" />' %}
+      {% assign new_meta_clip = og_image | append: twitter_image %}
+      {% assign seo_tags = seo_tags | replace: old_meta_clip, new_meta_clip %}
+    {% endif %}
+  
+    {{ seo_tags }}
+  
+    <title>
+      {%- unless page.layout == 'home' -%}
+        {{ page.title | append: ' | ' }}
+      {%- endunless -%}
+      {{ site.title }}
+    </title>
+  
+    {% include_cached favicons.html %}
+  
+    <!-- Resource Hints -->
+    {% unless site.assets.self_host.enabled %}
+      {% for hint in site.data.origin.cors.resource_hints %}
+        {% for link in hint.links %}
+          <link rel="{{ link.rel }}" href="{{ hint.url }}" {{ link.opts | join: ' ' }}>
+        {% endfor %}
+      {% endfor %}
+    {% endunless %}
+  
+    <!-- Bootstrap -->
+    {% unless jekyll.environment == 'production' %}
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    {% endunless %}
+  
+    <!-- Theme style -->
+    <link rel="stylesheet" href="{{ '/assets/css/:THEME.css' | replace: ':THEME', site.theme | relative_url }}">
+  
+    <!-- Web Font -->
+    <link rel="stylesheet" href="{{ site.data.origin[type].webfonts | relative_url }}">
+  
+    <!-- Font Awesome Icons -->
+    <link rel="stylesheet" href="{{ site.data.origin[type].fontawesome.css | relative_url }}">
+  
+    <!-- 3rd-party Dependencies -->
+  
+    {% if site.toc and page.toc %}
+      <link rel="stylesheet" href="{{ site.data.origin[type].toc.css | relative_url }}">
+    {% endif %}
+  
+    {% if page.layout == 'post' or page.layout == 'page' or page.layout == 'home' or page.layout == 'til' %}
+      <link rel="stylesheet" href="{{ site.data.origin[type]['lazy-polyfill'].css | relative_url }}">
+    {% endif %}
+  
+    {% if page.layout == 'page' or page.layout == 'post' or page.layout == 'til' %}
+      <!-- Image Popup -->
+      <link rel="stylesheet" href="{{ site.data.origin[type].glightbox.css | relative_url }}">
+    {% endif %}
+  
+    <!-- Scripts -->
+  
+    <script src="{{ '/assets/js/dist/theme.min.js' | relative_url }}"></script>
+  
+    {% include js-selector.html lang=lang %}
+  
+    {% if jekyll.environment == 'production' %}
+      <!-- PWA -->
+      {% if site.pwa.enabled %}
+        <script
+          defer
+          src="{{ '/app.min.js' | relative_url }}?baseurl={{ site.baseurl | default: '' }}&register={{ site.pwa.cache.enabled }}"
+        ></script>
+      {% endif %}
+  
+      <!-- Web Analytics -->
+      {% for analytics in site.analytics %}
+        {% capture str %}{{ analytics }}{% endcapture %}
+        {% assign platform = str | split: '{' | first %}
+        {% if site.analytics[platform].id and site.analytics[platform].id != empty %}
+          {% include analytics/{{ platform }}.html %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  
+    {% include metadata-hook.html %}
+  </head>
+  

--- a/_includes/js-selector.html
+++ b/_includes/js-selector.html
@@ -1,0 +1,89 @@
+<!-- JS selector for site. -->
+
+<!-- commons -->
+
+{% assign urls = site.data.origin[type].search.js %}
+
+<!-- layout specified -->
+
+{% if page.layout == 'post' or page.layout == 'page' or page.layout == 'home' or page.layout == 'til' %}
+  {% assign urls = urls | append: ',' | append: site.data.origin[type]['lazy-polyfill'].js %}
+
+  {% unless page.layout == 'home' %}
+    <!-- image lazy-loading & popup & clipboard -->
+    {% assign urls = urls
+      | append: ','
+      | append: site.data.origin[type].glightbox.js
+      | append: ','
+      | append: site.data.origin[type].clipboard.js
+    %}
+  {% endunless %}
+{% endif %}
+
+{% if page.layout == 'home'
+  or page.layout == 'post'
+  or page.layout == 'archives'
+  or page.layout == 'category'
+  or page.layout == 'tag'
+  or page.layout == 'til'
+%}
+  {% assign locale = include.lang | split: '-' | first %}
+
+  {% assign urls = urls
+    | append: ','
+    | append: site.data.origin[type].dayjs.js.common
+    | append: ','
+    | append: site.data.origin[type].dayjs.js.locale
+    | replace: ':LOCALE', locale
+    | append: ','
+    | append: site.data.origin[type].dayjs.js.relativeTime
+    | append: ','
+    | append: site.data.origin[type].dayjs.js.localizedFormat
+  %}
+{% endif %}
+
+{% if page.content contains '<h2' or page.content contains '<h3' and site.toc and page.toc %}
+  {% assign urls = urls | append: ',' | append: site.data.origin[type].toc.js %}
+{% endif %}
+
+{% if page.mermaid %}
+  {% assign urls = urls | append: ',' | append: site.data.origin[type].mermaid.js %}
+{% endif %}
+
+{% include jsdelivr-combine.html urls=urls %}
+
+{% case page.layout %}
+  {% when 'home', 'categories', 'post', 'page' %}
+    {% assign js = page.layout %}
+  {% when 'archives', 'category', 'tag' %}
+    {% assign js = 'misc' %}
+  {% when 'til' %}
+    {% assign js = 'post' %}
+  {% else %}
+    {% assign js = 'commons' %}
+{% endcase %}
+
+{% capture script %}/assets/js/dist/{{ js }}.min.js{% endcapture %}
+
+<script defer src="{{ script | relative_url }}"></script>
+
+{% if page.math %}
+  <!-- MathJax -->
+  <script async src="{{ '/assets/js/data/mathjax.js' | relative_url }}"></script>
+  <script async src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
+  <script id="MathJax-script" async src="{{ site.data.origin[type].mathjax.js | relative_url }}"></script>
+{% endif %}
+
+<!-- Pageviews -->
+{% if page.layout == 'post' or page.layout == 'til' %}
+  {% assign provider = site.pageviews.provider %}
+
+  {% if provider and provider != empty %}
+    {% case provider %}
+      {% when 'goatcounter' %}
+        {% if site.analytics[provider].id != empty and site.analytics[provider].id %}
+          {% include pageviews/{{ provider }}.html %}
+        {% endif %}
+    {% endcase %}
+  {% endif %}
+{% endif %}

--- a/_includes/read-time.html
+++ b/_includes/read-time.html
@@ -1,0 +1,39 @@
+<!-- Calculate the post's reading time, and display the word count in tooltip -->
+
+{% assign words = include.content | strip_html | number_of_words: 'auto' %}
+
+<!-- words per minute -->
+
+{% assign wpm = 180 %}
+{% assign min_time = 1 %}
+
+{% assign read_time = words | divided_by: wpm %}
+
+{% unless read_time > 0 %}
+  {% assign read_time = min_time %}
+{% endunless %}
+
+{% capture read_prompt %}
+  {{- site.data.locales[include.lang].post.read_time.prompt -}}
+{% endcapture %}
+
+{% unless words <= 100 %}
+  <!-- return element -->
+    <span
+    class="readtime"
+    data-bs-toggle="tooltip"
+    data-bs-placement="bottom"
+    title="{{ words }} {{ site.data.locales[include.lang].post.words }}"
+    >
+    <em>
+    {{- read_time -}}
+    {{ ' ' }}
+    {{- site.data.locales[include.lang].post.read_time.unit -}}
+    </em>
+    {%- if include.prompt -%}
+    {%- assign _prompt_words = read_prompt | number_of_words: 'auto' -%}
+    {%- unless _prompt_words > 1 -%}{{ ' ' }}{%- endunless -%}
+    {{ read_prompt }}
+    {%- endif -%}
+    </span>
+{% endunless %}

--- a/_includes/til-description.html
+++ b/_includes/til-description.html
@@ -1,0 +1,15 @@
+{%- comment -%}
+  Get post description or generate it from the post content.
+{%- endcomment -%}
+
+{%- assign max_length = include.max_length | default: 350 -%}
+
+{% capture description %}
+{% if post.description %}
+    {{- post.description -}}
+{% else %}
+    {{ post.content | truncate: max_length | markdownify }}
+{% endif %}
+{% endcapture %}
+
+{% include refactor-content.html content=description lang=lang %}

--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -1,0 +1,82 @@
+<!-- The Top Bar -->
+
+<header id="topbar-wrapper" aria-label="Top Bar">
+    <div
+      id="topbar"
+      class="d-flex align-items-center justify-content-between px-lg-3 h-100"
+    >
+      <nav id="breadcrumb" aria-label="Breadcrumb">
+        {% assign paths = page.url | split: '/' %}
+  
+        {% if paths.size == 0 or page.layout == 'home' %}
+          <!-- index page -->
+          <span>{{ site.data.locales[include.lang].tabs.home | capitalize }}</span>
+  
+        {% else %}
+          {% for item in paths %}
+            {% if forloop.first %}
+              <span>
+                <a href="{{ '/' | relative_url }}">
+                  {{- site.data.locales[include.lang].tabs.home | capitalize -}}
+                </a>
+              </span>
+  
+            {% elsif forloop.last %}
+              {% if page.collection == 'tabs' %}
+                <span>{{ site.data.locales[include.lang].tabs[item] | default: page.title }}</span>
+              {% else %}
+                <span>{{ page.title }}</span>
+              {% endif %}
+            {% elsif page.layout == 'category' or page.layout == 'tag' %}
+              <span>
+                <a href="{{ item | append: '/' | relative_url }}">
+                  {{- site.data.locales[include.lang].tabs[item] | default: page.title -}}
+                </a>
+              </span>
+            {% elsif page.layout == 'til' %}
+              <span>
+                <a href="{{ item | append: '/' | relative_url }}">
+                  TIL
+                </a>
+              </span>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      </nav>
+      <!-- endof #breadcrumb -->
+  
+      <button type="button" id="sidebar-trigger" class="btn btn-link">
+        <i class="fas fa-bars fa-fw"></i>
+      </button>
+  
+      <div id="topbar-title">
+        {% if page.layout == 'home' %}
+          {{- site.data.locales[include.lang].title | default: site.title -}}
+        {% elsif page.collection == 'tabs' or page.layout == 'page' %}
+          {%- capture tab_key -%}{{ page.url | split: '/' }}{%- endcapture -%}
+          {{- site.data.locales[include.lang].tabs[tab_key] | default: page.title -}}
+        {% else %}
+          {{- site.data.locales[include.lang].layout[page.layout] | default: page.layout | capitalize -}}
+        {% endif %}
+      </div>
+  
+      <button type="button" id="search-trigger" class="btn btn-link">
+        <i class="fas fa-search fa-fw"></i>
+      </button>
+  
+      <search id="search" class="align-items-center ms-3 ms-lg-0">
+        <i class="fas fa-search fa-fw"></i>
+        <input
+          class="form-control"
+          id="search-input"
+          type="search"
+          aria-label="search"
+          autocomplete="off"
+          placeholder="{{ site.data.locales[include.lang].search.hint | capitalize }}..."
+        >
+      </search>
+      <button type="button" class="btn btn-link text-decoration-none" id="search-cancel">
+        {{- site.data.locales[include.lang].search.cancel -}}
+      </button>
+    </div>
+  </header>

--- a/_layouts/til.html
+++ b/_layouts/til.html
@@ -1,0 +1,153 @@
+---
+layout: default
+refactor: true
+panel_includes:
+  - toc
+tail_includes:
+  - related-posts
+  - post-nav
+script_includes:
+  - comment
+---
+
+{% include lang.html %}
+
+{% include toc-status.html %}
+
+<article class="px-1" data-toc="{{ enable_toc }}">
+  <header>
+    <h1 data-toc-skip>{{ page.title }}</h1>
+    {% if page.description %}
+      <p class="post-desc fw-light mb-4">{{ page.description }}</p>
+    {% endif %}
+
+    <div class="post-meta text-muted">
+      <!-- published date -->
+      <span>
+        {{ site.data.locales[lang].post.posted }}
+        {% include datetime.html date=page.date tooltip=true lang=lang %}
+      </span>
+
+      <!-- lastmod date -->
+      {% if page.last_modified_at and page.last_modified_at != page.date %}
+        <span>
+          {{ site.data.locales[lang].post.updated }}
+          {% include datetime.html date=page.last_modified_at tooltip=true lang=lang %}
+        </span>
+      {% endif %}
+
+      {% if page.image %}
+        {% capture src %}src="{{ page.image.path | default: page.image }}"{% endcapture %}
+        {% capture class %}class="preview-img{% if page.image.no_bg %}{{ ' no-bg' }}{% endif %}"{% endcapture %}
+        {% capture alt %}alt="{{ page.image.alt | xml_escape | default: "Preview Image" }}"{% endcapture %}
+
+        {% if page.image.lqip %}
+          {%- capture lqip -%}lqip="{{ page.image.lqip }}"{%- endcapture -%}
+        {% endif %}
+
+        <div class="mt-3 mb-3">
+          <img {{ src }} {{ class }} {{ alt }} w="1200" h="630" {{ lqip }}>
+          {%- if page.image.alt -%}
+            <figcaption class="text-center pt-2 pb-2">{{ page.image.alt }}</figcaption>
+          {%- endif -%}
+        </div>
+      {% endif %}
+
+      <div class="d-flex justify-content-between">
+        <!-- author(s) -->
+        <span>
+          {% if page.author %}
+            {% assign authors = page.author %}
+          {% elsif page.authors %}
+            {% assign authors = page.authors %}
+          {% endif %}
+
+          {{ site.data.locales[lang].post.written_by }}
+
+          <em>
+            {% if authors %}
+              {% for author in authors %}
+                {% if site.data.authors[author].url -%}
+                  <a href="{{ site.data.authors[author].url }}">{{ site.data.authors[author].name }}</a>
+                {%- else -%}
+                  {{ site.data.authors[author].name }}
+                {%- endif %}
+                {% unless forloop.last %}{{ '</em>, <em>' }}{% endunless %}
+              {% endfor %}
+            {% else %}
+              <a href="{{ site.social.links[0] }}">{{ site.social.name }}</a>
+            {% endif %}
+          </em>
+        </span>
+
+        <div>
+          <!-- pageviews -->
+          {% if site.pageviews.provider and site.analytics[site.pageviews.provider].id %}
+            <span>
+              <em id="pageviews">
+                <i class="fas fa-spinner fa-spin small"></i>
+              </em>
+              {{ site.data.locales[lang].post.pageview_measure }}
+            </span>
+          {% endif %}
+
+          <!-- read time -->
+          {% include read-time.html content=content prompt=true lang=lang %}
+        </div>
+      </div>
+    </div>
+  </header>
+
+  {% if enable_toc %}
+    <div id="toc-bar" class="d-flex align-items-center justify-content-between invisible">
+      <span class="label text-truncate">{{ page.title }}</span>
+      <button type="button" class="toc-trigger btn me-1">
+        <i class="fa-solid fa-list-ul fa-fw"></i>
+      </button>
+    </div>
+
+    <button id="toc-solo-trigger" type="button" class="toc-trigger btn btn-outline-secondary btn-sm">
+      <span class="label ps-2 pe-1">{{- site.data.locales[lang].panel.toc -}}</span>
+      <i class="fa-solid fa-angle-right fa-fw"></i>
+    </button>
+
+    <dialog id="toc-popup" class="p-0">
+      <div class="header d-flex flex-row align-items-center justify-content-between">
+        <div class="label text-truncate py-2 ms-4">{{- page.title -}}</div>
+        <button id="toc-popup-close" type="button" class="btn mx-1 my-1 opacity-75">
+          <i class="fas fa-close"></i>
+        </button>
+      </div>
+      <div id="toc-popup-content" class="px-4 py-3 pb-4"></div>
+    </dialog>
+  {% endif %}
+
+  <div class="content">
+    {{ content }}
+  </div>
+
+  <div class="post-tail-wrapper text-muted">
+    <div
+      class="
+        post-tail-bottom
+        d-flex justify-content-between align-items-center mt-5 pb-2
+      "
+    >
+      <div class="license-wrapper">
+        {% if site.data.locales[lang].copyright.license.template %}
+          {% capture _replacement %}
+        <a href="{{ site.data.locales[lang].copyright.license.link }}">
+          {{ site.data.locales[lang].copyright.license.name }}
+        </a>
+        {% endcapture %}
+
+          {{ site.data.locales[lang].copyright.license.template | replace: ':LICENSE_NAME', _replacement }}
+        {% endif %}
+      </div>
+
+      {% include post-sharing.html lang=lang %}
+    </div>
+    <!-- .post-tail-bottom -->
+  </div>
+  <!-- div.post-tail-wrapper -->
+</article>

--- a/_posts/2024-12-15-why-i-take-daily-notes-in-obsidian.md
+++ b/_posts/2024-12-15-why-i-take-daily-notes-in-obsidian.md
@@ -5,9 +5,9 @@ date: 2024-12-15 23:11 -0600
 categories:
   - Journaling
 tags:
-  - obsidian
-  - journaling
-  - productivity
+  - Obsidian
+  - Journaling
+  - Productivity
 ---
 
 In the chaotic adventure of life, it’s easy to get caught up in the whirlwind of daily tasks and forget the epic story we’re trying to tell. That’s where daily notes come in. For me, taking daily notes isn’t just a productivity hack—it’s a way to capture the narrative, track my quests, and reflect on the journey. Think of it as the adventurer’s journal you wish you’d always kept.

--- a/_posts/2024-12-20-installing-homebrew-on-macos.md
+++ b/_posts/2024-12-20-installing-homebrew-on-macos.md
@@ -5,8 +5,8 @@ layout: post
 categories:
   - Developer Tools
 tags:
-  - mac-os
-  - developer-tools
+  - macOS
+  - Developer Tools
 ---
 
 So, you’ve got your shiny Mac running macOS, and you’re ready to turn it into a developer’s paradise. Enter **Homebrew**—the package manager that makes managing software on macOS a breeze. This guide will walk you through why you should use Homebrew, how to install it, and some tips and tricks to get the most out of it.

--- a/_posts/2024-12-29-trust-movement-setting-yearly-goals-in-obsidian.md
+++ b/_posts/2024-12-29-trust-movement-setting-yearly-goals-in-obsidian.md
@@ -4,10 +4,10 @@ title: 'Trust Movement: Setting Goals for an Action-Oriented Year'
 categories:
 - Journaling
 tags:
-- obsidian
-- productivity
-- journaling
-- goals
+- Obsidian
+- Productivity
+- Journaling
+- Goals
 date: 2024-12-29 11:15 -0600
 ---
 

--- a/_posts/2025-01-08-getting-started-with-jekyll-on-macos.md
+++ b/_posts/2025-01-08-getting-started-with-jekyll-on-macos.md
@@ -6,9 +6,9 @@ layout: post
 categories:
 - Developer Tools
 tags:
-- mac-os
-- jekyll
-- developer-tools
+- macOS
+- Jekyll
+- Developer Tools
 date: 2025-01-08 18:03 -0600
 ---
 So you want to set up a sleek new Jekyll site, but you’re staring at your terminal wondering why Ruby, Bundler, and a bunch of configuration files are involved. Fear not, intrepid site-builder, because I’ve got your back. Let’s walk through how to set up Ruby using `chruby` and Homebrew, install Bundler, and get Jekyll running smoothly on macOS.

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -1,7 +1,7 @@
 ---
-# the default layout is 'page'
+layout: page
 icon: fas fa-info-circle
-order: 4
+order: 2
 ---
 
 ## Hi there 👋 I'm Chandler

--- a/_tabs/til.md
+++ b/_tabs/til.md
@@ -1,0 +1,120 @@
+---
+layout: default
+title: "TIL"
+icon: fas fa-calendar-day
+order: 4
+refactor: true
+---
+
+{% include lang.html %}
+
+{% assign all_pinned = site.til | where: 'pin', 'true' %}
+{% assign all_normal = site.til | where_exp: 'item', 'item.pin != true and item.hidden != true' %}
+{% assign posts = site.til %}
+
+<!-- Get pinned posts on current page -->
+
+{% assign visible_start = paginator.page | minus: 1 | times: paginator.per_page %}
+{% assign visible_end = visible_start | plus: paginator.per_page %}
+
+{% if all_pinned.size > visible_start %}
+  {% if all_pinned.size > visible_end %}
+    {% assign pinned_size = paginator.per_page %}
+  {% else %}
+    {% assign pinned_size = all_pinned.size | minus: visible_start %}
+  {% endif %}
+
+  {% for i in (visible_start..all_pinned.size) limit: pinned_size %}
+    {% assign posts = posts | push: all_pinned[i] %}
+  {% endfor %}
+{% else %}
+  {% assign pinned_size = 0 %}
+{% endif %}
+
+<!-- Get normal posts on current page -->
+{% assign normal_size = paginator.posts | size | minus: pinned_size %}
+
+{% if normal_size > 0 %}
+  {% if pinned_size > 0 %}
+    {% assign normal_start = 0 %}
+  {% else %}
+    {% assign normal_start = visible_start | minus: all_pinned.size %}
+  {% endif %}
+
+  {% assign normal_end = normal_start | plus: normal_size | minus: 1 %}
+  {{ normal_start }} - {{ normal_end }}
+
+  {% for i in (normal_start..normal_end) %}
+    {% assign posts = posts | push: all_normal[i] %}
+  {% endfor %}
+{% endif %}
+
+## Today I Learned (TIL)
+
+**TIL** stands for **Today I Learned**. This is a collection of small, practical things I come across day-to-day, which I thought were worth remembering and sharing with other people. Content and code examples might not be completely accurate.
+
+<div id="post-list" class="flex-grow-1 px-xl-1">
+  {% for post in posts %}
+    <article class="card-wrapper card">
+      <a href="{{ post.url | relative_url }}" class="post-preview row g-0 flex-md-row-reverse">
+        {% assign card_body_col = '12' %}
+
+        {% if post.image %}
+          {% assign src = post.image.path | default: post.image %}
+          {% unless src contains '//' %}
+            {% assign src = post.media_subpath | append: '/' | append: src | replace: '//', '/' %}
+          {% endunless %}
+
+          {% assign alt = post.image.alt | xml_escape | default: 'Preview Image' %}
+
+          {% assign lqip = null %}
+
+          {% if post.image.lqip %}
+            {% capture lqip %}lqip="{{ post.image.lqip }}"{% endcapture %}
+          {% endif %}
+
+          <div class="col-md-5">
+            <img src="{{ src }}" alt="{{ alt }}" {{ lqip }}>
+          </div>
+
+          {% assign card_body_col = '7' %}
+        {% endif %}
+
+        <div class="col-md-{{ card_body_col }}">
+          <div class="card-body">
+            <h1 class="card-title my-2 mt-md-0">{{ post.title }}</h1>
+
+            <div class="card-text content mt-0 mb-3">
+              <div class="content">
+                {% include til-description.html %}
+              </div>
+            </div>
+
+            <div class="post-meta flex-grow-1 d-flex align-items-end">
+              <div class="me-auto">
+                <!-- posted date -->
+                <i class="far fa-calendar fa-fw me-1"></i>
+                {% include datetime.html date=post.date lang=lang %}
+
+              </div>
+
+              {% if post.pin %}
+                <div class="pin ms-1">
+                  <i class="fas fa-thumbtack fa-fw"></i>
+                  <span>{{ site.data.locales[lang].post.pin_prompt }}</span>
+                </div>
+              {% endif %}
+            </div>
+            <!-- .post-meta -->
+          </div>
+          <!-- .card-body -->
+        </div>
+      </a>
+    </article>
+  {% endfor %}
+</div>
+<!-- #post-list -->
+
+{% if paginator.total_pages > 1 %}
+  {% include post-paginator.html %}
+{% endif %}

--- a/_tabs/til.md
+++ b/_tabs/til.md
@@ -2,8 +2,7 @@
 layout: default
 title: "TIL"
 icon: fas fa-calendar-day
-order: 4
-refactor: true
+order: 1
 ---
 
 {% include lang.html %}

--- a/_til/adding-a-til-section-to-jekyll.md
+++ b/_til/adding-a-til-section-to-jekyll.md
@@ -1,0 +1,16 @@
+---
+layout: til
+title: "Adding a Today I Learned (TIL) section to my website"
+date: 2025-01-13 08:45 -0600
+tags: 
+- Jekyll
+---
+
+In `_config.yml`, I added a new collection specifically for TIL posts:
+
+```yaml
+collections:
+  til:
+    output: true
+    permalink: /til/:title/
+```

--- a/_til/integrating-jekyll-compose-with-my-til-collection.md
+++ b/_til/integrating-jekyll-compose-with-my-til-collection.md
@@ -1,0 +1,21 @@
+---
+layout: til
+title: Integrating Jekyll Compose with my TIL Collection
+date: 2025-01-15 08:53 -0600
+tags:
+- Jekyll
+---
+
+Since I have a custom layout for the TIL collection, I added default frontmatter for Jekyll Compose for the collection:
+
+```yaml
+jekyll_compose:
+  default_front_matter:
+    til:
+      layout: "til"
+```
+
+This allows me to use the following command to create a TIL.
+```sh
+bundle exec jekyll compose "Some TIL title here" --collection "til"
+``` 

--- a/archives/index.md
+++ b/archives/index.md
@@ -1,5 +1,6 @@
 ---
 layout: archives
+title: Archives
 icon: fas fa-archive
-order: 3
+collection: tabs
 ---

--- a/categories/index.md
+++ b/categories/index.md
@@ -1,5 +1,6 @@
 ---
 layout: categories
+title: Categories
 icon: fas fa-stream
-order: 1
+collection: tabs
 ---

--- a/tags/index.md
+++ b/tags/index.md
@@ -1,5 +1,6 @@
 ---
 layout: tags
+title: Tags
 icon: fas fa-tags
-order: 2
+collection: tabs
 ---


### PR DESCRIPTION
Quite a few modifications to the Chirpy theme in order to add a TIL section that behaves similarly to Posts. 

Some key differences from Posts:
- Categories and Tags are not supported (unsure about native support with jekyll-archives)
    - Tags are currently still used in TIL frontmatter to add related posts to the bottom of the TIL pages
- TIL pages are not currently in the RSS feed (I'd like to set up a separate feed)
